### PR TITLE
kvs_logkvs_create() can mount the stale bank, and fails to mount when its log ends near the bank boundary

### DIFF
--- a/src/kvstore_logkvs.c
+++ b/src/kvstore_logkvs.c
@@ -536,6 +536,40 @@ end:
     return ret;
 }
 
+/* Walk one bank's record log and report the offset just past its last valid
+ * record. Only used to disambiguate two banks carrying the same master-record
+ * version, a state legacy stores are stuck in (see the selection logic in
+ * kvs_logkvs_create). Deliberately tolerant: a scan that stops early on
+ * damaged data still yields a usable extent for the comparison, so this
+ * never fails the mount. Cost is one extra bank-sized walk at boot, and only
+ * when the versions actually tie. */
+static void scan_bank_log_end(kvs_t *kvs, uint8_t bank, uint32_t *log_end)
+{
+    kvs_logkvs_context_t *context = kvs->context;
+
+    uint32_t offset = context->master_record_offset;
+    uint32_t next_offset = 0;
+    uint32_t actual_data_size = 0;
+    uint32_t hash = 0;
+    uint32_t flags = 0;
+
+    while (offset + sizeof(record_header_t) < context->size) {
+        /* copy_key is false: only next_offset is consumed here, so there is no
+         * reason to copy each key out. read_record() then chunks the key
+         * through work_buf and only advances user_key_ptr without
+         * dereferencing it. key_buf is still passed rather than NULL because
+         * that pointer advance on NULL would be undefined. */
+        int ret = read_record(kvs, bank, offset, context->key_buf, 0, 0, &actual_data_size, 0, false,
+                              false, false, false, &hash, &flags, &next_offset);
+        if (ret != KVSTORE_SUCCESS)
+            break;
+        if (next_offset <= offset)  /* no forward progress — treat as damaged */
+            break;
+        offset = next_offset;
+    }
+    *log_end = offset;
+}
+
 static void update_all_iterators(kvs_t *kvs, bool added, uint32_t ram_index_ind) {
     kvs_logkvs_context_t *context = kvs->context;
 
@@ -1089,6 +1123,35 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
         if (bank_ver[0] != bank_ver[1]) {
             /* Signed difference so a uint16_t wrap compares correctly. */
             context->active_bank = ((int16_t)(bank_ver[0] - bank_ver[1]) > 0) ? 0 : 1;
+        } else {
+            /* Versions tie. Every device provisioned before this patch is
+             * permanently in this state, so we cannot simply trust the version
+             * and must infer which bank the last GC wrote.
+             *
+             * A bank is abandoned when it can no longer fit the record being
+             * written, so the abandoned bank is at/near full while the bank
+             * just compacted into holds only the live set. Prefer the bank that
+             * can still accept a record; failing that, the shorter log.
+             *
+             * This is a heuristic and it is wrong in one case: if a bank was
+             * abandoned early (GC can also fire from the incomplete-set guard
+             * in _set_start, well below full) and the current bank has since
+             * grown past that point, the shorter-log rule picks the stale bank.
+             * Accepted because it self-heals — the next GC writes a real
+             * incremented version, the versions diverge, and this branch is
+             * never taken on that device again. */
+            uint32_t end0 = 0, end1 = 0;
+            scan_bank_log_end(kvs, 0, &end0);
+            scan_bank_log_end(kvs, 1, &end1);
+
+            bool full0 = (end0 + sizeof(record_header_t) >= context->size);
+            bool full1 = (end1 + sizeof(record_header_t) >= context->size);
+
+            if (full0 != full1)
+                context->active_bank = full0 ? 1 : 0;
+            else if (end0 != end1)
+                context->active_bank = (end0 < end1) ? 0 : 1;
+            /* else: genuinely indistinguishable — keep the loop's pick. */
         }
     }
 

--- a/src/kvstore_logkvs.c
+++ b/src/kvstore_logkvs.c
@@ -1098,7 +1098,16 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
      * comparison above. */
     context->bank_version = bank_ver[context->active_bank];
 
-    context->free_space_offset = _size;
+    /* _size is never updated inside the master-scan loop above — it stays at
+     * (size_t)-1, which gives build_ram_index() an unbounded scan window and
+     * causes read_bank() to return READ_FAILED when the log approaches the
+     * bank boundary. That READ_FAILED cascades through build_ram_index() to
+     * kvs_logkvs_create() returning NULL, so any device whose bank fills to
+     * within sizeof(record_header_t) of the boundary fails to mount on
+     * reboot. Bound the scan by the bank size so the loop exits cleanly at
+     * the boundary; build_ram_index() still finds the true free space via
+     * next_offset from the last valid record. */
+    context->free_space_offset = context->size;
     ret = build_ram_index(kvs);
     if ((ret != KVSTORE_SUCCESS) && (ret != KVSTORE_ERROR_INVALID_DATA_DETECTED)) {
         goto fail;

--- a/src/kvstore_logkvs.c
+++ b/src/kvstore_logkvs.c
@@ -1080,7 +1080,16 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
 
     if ((bank_state[0] == KVSTORE_BANK_STATE_VALID) &&
         (bank_state[1] == KVSTORE_BANK_STATE_VALID)) {
-        ;  //
+        /* Both banks are valid, so pick the one with the newer master-record
+         * version. Without this, active_bank keeps whatever the scan loop
+         * above assigned last (always bank 1), and a device whose most
+         * recent garbage collection landed on bank 0 mounts the stale bank 1
+         * on its next boot. Because a bank is abandoned precisely when it
+         * fills, that stale bank is always at or near its boundary. */
+        if (bank_ver[0] != bank_ver[1]) {
+            /* Signed difference so a uint16_t wrap compares correctly. */
+            context->active_bank = ((int16_t)(bank_ver[0] - bank_ver[1]) > 0) ? 0 : 1;
+        }
     }
 
     /* Restore the version of whichever bank was mounted. Without this,

--- a/src/kvstore_logkvs.c
+++ b/src/kvstore_logkvs.c
@@ -954,7 +954,7 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
     int ret = KVSTORE_SUCCESS;
     uint32_t flags;
     uint32_t hash;
-    master_record_data_t master_rec;
+    master_record_data_t master_rec = {0};
     uint32_t next_offset;
 
     kvs_t *kvs = calloc(1, sizeof(kvs_t));
@@ -1026,6 +1026,9 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
     bank_state_t bank_state[KVSTORE_NUM_BANK];
 
     size_t _size = (size_t)-1;
+    /* Capture each bank's on-flash master-record version at read time so the
+     * selection below can compare them. */
+    uint16_t bank_ver[KVSTORE_NUM_BANK] = {0};
     for (uint8_t bank = 0; bank < KVSTORE_NUM_BANK; bank++) {
         bank_state[bank] = KVSTORE_BANK_STATE_NONE;
 
@@ -1044,7 +1047,20 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
         }
 
         bank_state[bank] = KVSTORE_BANK_STATE_VALID;
+        /* Only a clean read leaves master_rec trustworthy. The tolerated
+         * non-success returns above either bail out before the data buffer is
+         * touched (READ_FAILED) or fill it from a record that is not the
+         * master record (ITEM_NOT_FOUND on a foreign key at this offset), so
+         * reading .version on those paths would invent a version. Leaving it
+         * at 0 keeps this bank losing the comparison below rather than
+         * winning it with garbage — and a garbage version would persist,
+         * since the next garbage collection writes bank_version + 1 to flash. */
+        if (ret == KVSTORE_SUCCESS) {
+            bank_ver[bank] = master_rec.version;
+        }
 
+        /* Provisional: correct when exactly one bank is valid. The both-valid
+         * case is resolved properly below. */
         context->active_bank = bank;
     }
     if ((bank_state[0] == KVSTORE_BANK_STATE_INVALID) &&
@@ -1066,6 +1082,12 @@ kvs_t *kvs_logkvs_create(blockdevice_t *bd) {
         (bank_state[1] == KVSTORE_BANK_STATE_VALID)) {
         ;  //
     }
+
+    /* Restore the version of whichever bank was mounted. Without this,
+     * context->bank_version stays at its calloc'd 0 and every
+     * garbage_collection() writes version 1, permanently defeating the
+     * comparison above. */
+    context->bank_version = bank_ver[context->active_bank];
 
     context->free_space_offset = _size;
     ret = build_ram_index(kvs);

--- a/tests/test_logkvs.c
+++ b/tests/test_logkvs.c
@@ -188,6 +188,88 @@ static void test_various_size_value_garbage_collection(kvs_t *kvs) {
     }
 }
 
+/* kvs_logkvs_create() decides which bank to mount exactly once, at create
+ * time, so the only way to exercise that decision is to remount. A single
+ * garbage collection proves nothing here: it moves the active bank from 0 to
+ * 1, and the pre-fix mount's both-banks-valid fallback keeps whatever the
+ * scan loop assigned last -- which is always bank 1 -- so a lone GC "passes"
+ * by accident regardless of which bank is actually correct. A second
+ * collection is needed to bring the active bank back to 0, leaving bank 1
+ * full and stale. Only then does a remount actually discriminate: the
+ * correct answer is bank 0, but the pre-fix fallback always says bank 1.
+ *
+ * Earlier cases in this suite may leave either bank active, so this case
+ * first normalizes to bank 0 with however many single-GC flips that takes
+ * (0 or 1), rather than assuming what ran before it. Skipping that step and
+ * simply recording whichever bank happened to be active would silently stop
+ * discriminating the defect whenever that bank was already 1 -- the buggy
+ * fallback's answer would coincidentally match the correct one.
+ *
+ * The remount itself is a bare kvs_logkvs_create(device) with no preceding
+ * kvs_logkvs_free(). A real reboot never frees anything either -- the old
+ * in-RAM state just goes away when the device resets, and the flash is what
+ * survives. Calling kvs_logkvs_free() first would be the wrong simulation on
+ * this test double: it flushes through to the underlying blockdevice's own
+ * deinit, which for blockdevice_heap releases the malloc'd buffer that IS
+ * the storage under test -- destroying the very state a remount is supposed
+ * to read back. Recreating without freeing leaves that old kvs_t
+ * unreachable for the rest of the test, same as it would be after a real
+ * reboot. */
+static kvs_t *test_bank_selection_after_remount(kvs_t *kvs, blockdevice_t *device) {
+    kvs_logkvs_context_t *context = kvs->context;
+    int result;
+    char value[16] = {0};
+    size_t value_size = 0;
+    const char *canary = "remount_canary";
+
+    test_printf("bank selection across a remount");
+
+    while (context->active_bank != 0) {
+        result = kvs->set(kvs, key3, key3_value1, strlen(key3_value1), 0);
+        assert(result == KVSTORE_SUCCESS);
+    }
+
+    result = kvs->set(kvs, canary, "first", strlen("first"), 0);
+    assert(result == KVSTORE_SUCCESS);
+    while (true) {
+        result = kvs->set(kvs, key3, key3_value1, strlen(key3_value1), 0);
+        assert(result == KVSTORE_SUCCESS);
+        if (context->active_bank != 0) {
+            break;
+        }
+    }
+    assert(context->active_bank == 1);
+
+    result = kvs->set(kvs, canary, "second", strlen("second"), 0);
+    assert(result == KVSTORE_SUCCESS);
+    while (true) {
+        result = kvs->set(kvs, key3, key3_value1, strlen(key3_value1), 0);
+        assert(result == KVSTORE_SUCCESS);
+        if (context->active_bank != 1) {
+            break;
+        }
+    }
+    assert(context->active_bank == 0);
+
+    result = kvs->set(kvs, canary, "third", strlen("third"), 0);
+    assert(result == KVSTORE_SUCCESS);
+
+    kvs = kvs_logkvs_create(device);
+    assert(kvs != NULL);
+    context = kvs->context;
+
+    assert(context->active_bank == 0);
+
+    result = kvs->get(kvs, canary, value, sizeof(value), &value_size, 0);
+    assert(result == KVSTORE_SUCCESS);
+    assert(value_size == strlen("third"));
+    assert(memcmp("third", value, value_size) == 0);
+
+    printf(COLOR_GREEN("ok\n"));
+
+    return kvs;
+}
+
 void test_kvstore_logkvs(void) {
 #if PICO_ON_DEVICE
     printf("Log Key-Value Store, Flash memory:\n");
@@ -206,6 +288,7 @@ void test_kvstore_logkvs(void) {
     test_various_size_key(kvs);
     test_various_size_value(kvs);
     test_various_size_value_garbage_collection(kvs);
+    kvs = test_bank_selection_after_remount(kvs, device);
 
     cleanup(device);
     kvs_logkvs_free(kvs);


### PR DESCRIPTION
## Summary

`kvs_logkvs_create()` can mount the wrong bank after a reboot, and in one specific case
fails to mount at all. This is not a rare edge case: on a fleet of 12 field devices, 11
were already sitting in the exact precondition that makes it happen — of which 4 were
one reboot away from mounting the stale bank — and one had already lost its store. This
PR fixes the root cause with three small, ordered commits, adds a
host-runnable regression test that runs in this repository's own CI, and includes a
fourth commit that migrates already-deployed stores through the transition safely — with
an easy way to decline it if you'd rather not carry the heuristic.

## Root cause

Three defects interact in `kvs_logkvs_create()` (`src/kvstore_logkvs.c`), and the order
in which they matter is not obvious from reading the function top to bottom.

**The operative bug is the empty tie-break.** When both banks carry a valid master
record, the selection code is:

```c
if ((bank_state[0] == KVSTORE_BANK_STATE_VALID) &&
    (bank_state[1] == KVSTORE_BANK_STATE_VALID)) {
    ;  // nothing
}
```

Nothing there means `active_bank` is left at whatever the preceding scan loop assigned
last — which, for a loop over two banks, is unconditionally bank 1. The two banks'
versions are never actually compared. So even when `master_rec.version` genuinely
differs between the banks, the mount ignores it and always picks bank 1.

**What makes it permanent: `context->bank_version` is never restored from flash.**
`context` is `calloc`'d, so `bank_version` starts at 0 on every boot regardless of what
is on flash. It is only ever assigned in two other places — `context->bank_version = 1`
on a fresh-init, and `context->bank_version++`/`--` inside `garbage_collection()`. The
mount path reads `master_rec` (with `copy_data=true`, so the on-flash version *is*
available) and then never looks at it again. The result: every garbage collection ever
performed stamps a value that starts from 0 each boot, so **every device that has GC'd
at most once per power cycle shows version 1 in both banks, forever** — even though one
bank is current and the other is stale.

**The escalation: an unbounded `build_ram_index()` scan.** `free_space_offset` is
derived from a local that is initialized to `(size_t)-1` and never assigned, so the scan
loop's terminator is effectively infinite:

```c
while (offset + sizeof(record_header_t) < context->free_space_offset) {
```

This is usually harmless — the scan runs into erased flash and the caller tolerates the
resulting `INVALID_DATA_DETECTED`. It stops being harmless when the selected bank's log
ends within `sizeof(record_header_t)` (24 bytes) of the bank boundary: `read_bank()`'s
own bounds check fires first and returns `READ_FAILED`, which the caller does **not**
tolerate — `kvs_logkvs_create()` returns `NULL`.

**Putting it together:** a bank is abandoned by garbage collection precisely when it is
full — that's what triggers the GC. So the bank the empty tie-break wrongly selects is
guaranteed to be at or near full. Whether that produces a silent rollback to stale data
or a hard mount failure depends only on how many bytes happened to be left over in that
bank when it was abandoned. We observed both outcomes on the same class of device,
differing only by an 8-byte margin.

## Reproduction — fails on unpatched, passes on patched, runs in this repo's own CI

`kvs_logkvs_create()` decides which bank to mount exactly once, at create time, so this
can only be exercised by remounting. The included test (appended to the existing,
already-registered `tests/test_logkvs.c` — no `CMakeLists.txt` or `main.c` change)
normalizes to bank 0, forces two garbage collections so the correct post-remount answer
is specifically bank 0 (the pre-fix fallback always keeps bank 1 regardless of the data,
so the case only discriminates reliably when the correct answer is the *other* bank),
then tears down and recreates the `kvs_t` over the same, un-erased blockdevice — a more
faithful reboot simulation than freeing first, since a real reboot never frees anything
either.

This repository's own `.github/workflows/host-unittest.yml` already configures with
`-DPICO_PLATFORM=host -DCMAKE_BUILD_TYPE=Debug`, builds the `unittest` target, and runs
`./tests/unittest` on every push — no hardware needed, and no new CI configuration
required for this PR. On the unpatched tree it aborts:

```
Assertion failed: (context->active_bank == 0), function test_bank_selection_after_remount, file test_logkvs.c, line 261.
```

every case before it — including the pre-existing `garbage collection` case, whose
`bank_version == 1, 2, 3` assertions this patch must not disturb — reaches `ok` first,
so the failure is isolated to the new case. On the patched tree the full suite passes.
The reproduction does not depend on the final (migration) commit below — reverting that
commit and re-running still passes, because the case discriminates on version
divergence, not on the migration heuristic.

## Field evidence

**12 devices in the field, 11 found at version 1/1 as predicted, 1 with total config
loss.** All twelve were dumped and inspected before any of them was opened, and the
version-1/1 state was predicted from reading the code, then confirmed in the field —
that ordering is what makes this evidence load-bearing rather than anecdotal.

Redacted per-device structure (chip identifiers replaced with `device-1` through
`device-12`; no raw dumps, no key names, no values):

| device | bank 0 | bank 1 | state |
|---|---|---|---|
| device-1  | v1 24 rec 1.6% live | v1 1287 rec 100.0% stale | HAZARD |
| device-2  | v1 270 rec 20.8% live | v1 610 rec 47.2% stale | HAZARD |
| device-3  | v1 545 rec 42.2% live | v1 453 rec 35.0% stale | HAZARD |
| device-4  | v2 1 rec 0.0% | v3 1 rec 0.0% | BROKEN |
| device-5  | v1 1287 rec 100.0% FULL stale | v1 974 rec 75.5% live | safe |
| device-6  | v1 1335 rec 100.0% FULL stale | v1 624 rec 46.9% live | safe |
| device-7  | v1 1333 rec 100.0% stale | v1 618 rec 46.4% live | safe |
| device-8  | v1 1332 rec 99.9% stale | v1 480 rec 35.9% live | safe |
| device-9  | v1 1335 rec 100.0% FULL stale | v1 491 rec 36.8% live | safe |
| device-10 | v1 573 rec 44.4% live | v1 1029 rec 79.8% stale | HAZARD |
| device-11 | v1 1288 rec 100.0% FULL stale | v1 982 rec 76.2% live | safe |
| device-12 | v1 1288 rec 100.0% FULL stale | v1 981 rec 76.1% live | safe |

`HAZARD` means the device was one reboot away from mounting the stale bank (a rollback,
or a hard failure if the stale bank's leftover landed under 24 bytes of its boundary).
`device-4` is the one already-broken device: repeated write failures on that unit
triggered garbage collection three times in a single power cycle (see the linked issue
for why that's possible at all), which is how its versions reached 2/3 rather than the
1/1 every other device showed — and is itself informative, not a contradiction of the
root cause.

## Commit walkthrough

Three principled fixes first, then the test, then a clearly separable migration commit
at the tip:

1. **`logkvs: restore bank_version from the mounted bank`** — captures each bank's
   on-flash master-record version during the mount scan and restores
   `context->bank_version` from whichever bank is selected, so later comparisons have
   something real to compare.
2. **`logkvs: select the newer bank when both banks are valid`** — fills in the empty
   tie-break with a real signed-difference comparison of the two banks' versions
   (tolerant of `uint16_t` wraparound). This is the operative fix.
3. **`logkvs: bound the RAM index scan to the bank size`** — bounds
   `context->free_space_offset` by the bank size instead of leaving it at its
   uninitialized `(size_t)-1`, so a log ending near the boundary degrades to the
   tolerated `INVALID_DATA_DETECTED` instead of a hard `READ_FAILED`.
4. **`tests: cover bank selection across a remount`** — the reproduction described
   above.
5. **`logkvs: disambiguate equal bank versions on legacy stores`** — see below.

### An offer, not an obligation

The final commit is a heuristic for the specific legacy case where both banks still read
version 1/1 — every store written before commit 1 lands there, including every existing
`pico-kvstore` deployment. It adds `scan_bank_log_end()` and a single caller in the
`else` branch that would otherwise still fall through to "keep the last assignment." The
helper and its only caller are deliberately kept in this one commit, at the tip, so if
you'd rather not carry a heuristic in the mount path, `git revert` on this single commit
removes it cleanly — no `-Wunused-function` warning, no rework, and the reproduction
above still passes without it (it discriminates on version divergence, which this commit
doesn't touch).

The heuristic is honestly imperfect: if a bank was abandoned early — garbage collection
can also fire from the incomplete-set guard well below full — and the other bank has
since grown past that abandonment point, the shorter-log rule it uses will pick the
stale bank. This self-heals: the next garbage collection on that device writes a real
incremented version, the two banks' versions diverge, and this branch is never taken
again on that device.

### Why it's included anyway

Without this commit, an already-deployed device gets no rescue on its first boot after
taking commits 1-3. Both banks still read version 1 (nothing has stamped a different
value yet), the comparison in commit 2 sees a tie, and falls through to "keep the loop's
pick" — bank 1. If bank 1 happens to be the stale, full bank, the original failure
recurs on the very first boot the fix was supposed to prevent. Versions only start to
diverge after that device's *next* garbage collection. Every existing `pico-kvstore`
deployment is in this same version-1/1 state right now, which makes this a necessary
migration path for the fix to actually help anyone already running the library, not a
downstream-specific convenience.

---

Related issue (separate defect, not fixed by this PR): https://github.com/oyama/pico-kvstore/issues/9
